### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This MCP server integrates Honeybadger error tracking with Cursor IDE, allowing you to fetch and analyze errors directly from your development environment.
 
+<a href="https://glama.ai/mcp/servers/@vishalzambre/honeybadger-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@vishalzambre/honeybadger-mcp/badge" alt="Honeybadger Server MCP server" />
+</a>
+
 <a href="https://www.buymeacoffee.com/vishalzambre" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 ## Prerequisites


### PR DESCRIPTION
This PR adds a badge for the [Honeybadger MCP Server](https://glama.ai/mcp/servers/@vishalzambre/honeybadger-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@vishalzambre/honeybadger-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@vishalzambre/honeybadger-mcp/badge" alt="Honeybadger Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.